### PR TITLE
fix(pipeline.yml): upgrade actions/upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
See https://github.com/orgs/community/discussions/152695 - this might explain the recent failure of the pipeline when pushing to main